### PR TITLE
Replaced subprocess.run with subprocess.check_call

### DIFF
--- a/scotttv.py
+++ b/scotttv.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 import RPi.GPIO as GPIO
 
-subprocess.run(['setterm', '-blank', 'force'])  # doesn't capture output
+subprocess.check_call(['setterm', '-blank', 'force'])  # doesn't capture output
 
 #set up GPIO using BCM numbering
 


### PR DESCRIPTION
This should fix #1 and make it work for Python 3.4

I have not tested it. Made the edits straight in the browser so no chance for testing ;) Hope it works!
